### PR TITLE
Use username jobname and jobid for output and error paths in sbatch  

### DIFF
--- a/lumi/lumi_jobscript.sh
+++ b/lumi/lumi_jobscript.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-#SBATCH --output=/scratch/project_465001383/aifs/logs/LOGNAME.out
-#SBATCH --error=/scratch/project_465001383/aifs/logs/LOGNAME.err
+#SBATCH --output=/scratch/project_465001383/%u/logs/%x.out
+#SBATCH --error=/scratch/project_465001383/%u/logs/%x.err
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=8
 #SBATCH --account=project_465001383
@@ -15,11 +15,11 @@
 CONFIG_NAME=CONFIGNAME.yaml #This file should be located in run-anemoi/lumi
 
 #Should not have to change these
-PROJECT_DIR=/pfs/lustrep4/scratch/$SLURM_JOB_ACCOUNT
-CONTAINER_SCRIPT=/pfs/lustrep4/$(pwd)/run_pytorch.sh
-CONFIG_DIR=/pfs/lustrep4/$(pwd)
+PROJECT_DIR=/scratch/$SLURM_JOB_ACCOUNT
+CONTAINER_SCRIPT=$(pwd)/run_pytorch.sh
+CONFIG_DIR=$(pwd)
 CONTAINER=$PROJECT_DIR/aifs/container/containers/anemoi-training-pytorch-2.2.2-rocm-5.6.1-py-3.11.5.sif
-VENV=/pfs/lustrep4/$(pwd)/.venv
+VENV=$(pwd)/.venv
 export VIRTUAL_ENV=$VENV
 
 module load LUMI/23.09 partition/G

--- a/lumi/lumi_jobscript.sh
+++ b/lumi/lumi_jobscript.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-#SBATCH --output=/scratch/project_465001383/%u/logs/%x.out
-#SBATCH --error=/scratch/project_465001383/%u/logs/%x.err
+#SBATCH --output=/scratch/project_465001383/%u/logs/%x_%j.out
+#SBATCH --error=/scratch/project_465001383/%u/logs/%x_%j.err
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=8
 #SBATCH --account=project_465001383

--- a/lumi/lumi_jobscript.sh
+++ b/lumi/lumi_jobscript.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-#SBATCH --output=/scratch/project_465001383/%u/logs/%x_%j.out
-#SBATCH --error=/scratch/project_465001383/%u/logs/%x_%j.err
+#SBATCH --output=/users/%u/%x_%j.out
+#SBATCH --error=/users/%u/%x_%j.err
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=8
 #SBATCH --account=project_465001383
@@ -16,10 +16,10 @@ CONFIG_NAME=CONFIGNAME.yaml #This file should be located in run-anemoi/lumi
 
 #Should not have to change these
 PROJECT_DIR=/scratch/$SLURM_JOB_ACCOUNT
-CONTAINER_SCRIPT=$(pwd)/run_pytorch.sh
-CONFIG_DIR=$(pwd)
+CONTAINER_SCRIPT=$(pwd -P)/run_pytorch.sh
+CONFIG_DIR=$(pwd -P)
 CONTAINER=$PROJECT_DIR/aifs/container/containers/anemoi-training-pytorch-2.2.2-rocm-5.6.1-py-3.11.5.sif
-VENV=$(pwd)/.venv
+VENV=$(pwd -P)/.venv
 export VIRTUAL_ENV=$VENV
 
 module load LUMI/23.09 partition/G


### PR DESCRIPTION
See https://slurm.schedmd.com/sbatch.html 

`%u`  expands to username `%x` expands to job name `%j` is the job id. 
We can maybe come up with a better naming convention for the log files but at least the log files should be in a username dependent directory by default. 
 
This PR also removes the `/pfs/lustrep4/` part of some paths.  This is causing problems in my case because my home directory is on  `/pfs/lustrep3`.  Just removing the `/pfs/lustrep4`  ensures that the paths will always be valid.     