### PR TITLE
Use https when doing git clone (no pwd)

### DIFF
--- a/lumi/env_setup.sh
+++ b/lumi/env_setup.sh
@@ -11,7 +11,7 @@ export PATH=$PATH:VIRTUAL_ENV/bin
 for repo in datasets models training graphs; do
     if [ ! -d anemoi-$repo ]; then
         echo "Cloning $repo"
-        git clone git@github.com:metno/anemoi-$repo.git
+        git clone https://github.com/metno/anemoi-$repo.git
     fi
     pip install --user --no-deps -e anemoi-$repo
 done
@@ -19,7 +19,7 @@ done
 for repo in utils; do
     if [ ! -d anemoi-$repo ]; then
         echo "Cloning $repo"
-        git clone git@github.com:ecmwf/anemoi-$repo.git
+        git clone https://github.com/ecmwf/anemoi-$repo.git
     fi
     pip install --user --no-deps -e anemoi-$repo
 done

--- a/lumi/env_setup.sh
+++ b/lumi/env_setup.sh
@@ -12,6 +12,9 @@ for repo in datasets models training graphs; do
     if [ ! -d anemoi-$repo ]; then
         echo "Cloning $repo"
         git clone https://github.com/metno/anemoi-$repo.git
+        cd anemoi-$repo
+	git remote set-url origin git@github.com:metno/anemoi-$repo.git
+        cd ..
     fi
     pip install --user --no-deps -e anemoi-$repo
 done
@@ -20,6 +23,9 @@ for repo in utils; do
     if [ ! -d anemoi-$repo ]; then
         echo "Cloning $repo"
         git clone https://github.com/ecmwf/anemoi-$repo.git
+        cd anemoi-$repo
+        git remote set-url origin git@github.com:metno/anemoi-$repo.git
+        cd ..
     fi
     pip install --user --no-deps -e anemoi-$repo
 done

--- a/lumi/env_setup_core.sh
+++ b/lumi/env_setup_core.sh
@@ -11,7 +11,7 @@ export PATH=$PATH:$VIRTUAL_ENV/bin
 # Clone anemoi-core if not already cloned
 if [ ! -d anemoi-core ]; then
     echo "Cloning anemoi-core from metno"
-    git clone --branch develop git@github.com:metno/anemoi-core.git
+    git clone --branch develop https://github.com/metno/anemoi-core.git
 fi
 
 # Install training, models, and graphs from anemoi-core
@@ -23,13 +23,13 @@ pip install --user --no-deps -e anemoi-core/graphs
 # Clone and install utils if not already cloned
 if [ ! -d anemoi-utils ]; then
     echo "Cloning anemoi-utils from ecmwf"
-    git clone git@github.com:ecmwf/anemoi-utils.git
+    git clone https://github.com/ecmwf/anemoi-utils.git
 fi
 pip install --user --no-deps -e anemoi-utils
 
 # Clone and install datasets if not already cloned
 if [ ! -d anemoi-datasets ]; then
     echo "Cloning anemoi-datasets from metno"
-    git clone git@github.com:metno/anemoi-datasets.git
+    git clone https://github.com/metno/anemoi-datasets.git
 fi
 pip install --user --no-deps -e anemoi-datasets

--- a/lumi/env_setup_core.sh
+++ b/lumi/env_setup_core.sh
@@ -12,6 +12,9 @@ export PATH=$PATH:$VIRTUAL_ENV/bin
 if [ ! -d anemoi-core ]; then
     echo "Cloning anemoi-core from metno"
     git clone --branch develop https://github.com/metno/anemoi-core.git
+    cd anemoi-core
+    git remote set-url origin git@github.com:metno/anemoi-core.git
+    cd ..
 fi
 
 # Install training, models, and graphs from anemoi-core
@@ -24,6 +27,9 @@ pip install --user --no-deps -e anemoi-core/graphs
 if [ ! -d anemoi-utils ]; then
     echo "Cloning anemoi-utils from ecmwf"
     git clone https://github.com/ecmwf/anemoi-utils.git
+    cd anemoi-utils
+    git remote set-url origin git@github.com:ecmwf/anemoi-utils.git
+    cd ..
 fi
 pip install --user --no-deps -e anemoi-utils
 
@@ -31,5 +37,8 @@ pip install --user --no-deps -e anemoi-utils
 if [ ! -d anemoi-datasets ]; then
     echo "Cloning anemoi-datasets from metno"
     git clone https://github.com/metno/anemoi-datasets.git
+    cd anemoi-datasets
+    git remote set-url origin git@github.com:metno/anemoi-datasets.git
+    cd ..
 fi
 pip install --user --no-deps -e anemoi-datasets

--- a/lumi/env_setup_infer.sh
+++ b/lumi/env_setup_infer.sh
@@ -11,5 +11,8 @@ export PATH=$PATH:VIRTUAL_ENV/bin
 if [ ! -d bris-inference ]; then
     echo "Cloning bris-inference"
     git clone https://github.com/metno/bris-inference.git
+    cd bris-inference
+    git remote set-url origin git@github.com:metno/bris-inference.git
+    cd ..
 fi
 pip install --user --no-deps -e bris-inference

--- a/lumi/env_setup_infer.sh
+++ b/lumi/env_setup_infer.sh
@@ -10,6 +10,6 @@ export PATH=$PATH:VIRTUAL_ENV/bin
 
 if [ ! -d bris-inference ]; then
     echo "Cloning bris-inference"
-    git clone git@github.com:metno/bris-inference.git
+    git clone https://github.com/metno/bris-inference.git
 fi
 pip install --user --no-deps -e bris-inference


### PR DESCRIPTION
For all env_setup files: 
- use https when clone so dont have to write password a million times. 
- then setting the git remote url so that you can easily pull/push over ssh (without being asked for username/password) 
