### PR TITLE
Fix: https git clone & install in edit mode not working

### DIFF
--- a/lumi/env_setup.sh
+++ b/lumi/env_setup.sh
@@ -16,7 +16,7 @@ for repo in datasets models training graphs; do
 	git remote set-url origin git@github.com:metno/anemoi-$repo.git
         cd ..
     fi
-    pip install --user --no-deps -e anemoi-$repo
+    pip install --no-deps -e anemoi-$repo
 done
 
 for repo in utils; do
@@ -24,7 +24,7 @@ for repo in utils; do
         echo "Cloning $repo"
         git clone https://github.com/ecmwf/anemoi-$repo.git
     fi
-    pip install --user --no-deps -e anemoi-$repo
+    pip install --no-deps -e anemoi-$repo
 done
 
    

--- a/lumi/env_setup_core.sh
+++ b/lumi/env_setup_core.sh
@@ -19,9 +19,9 @@ fi
 
 # Install training, models, and graphs from anemoi-core
 echo "Installing training, models, and graphs from anemoi-core"
-pip install --user --no-deps -e anemoi-core/training
-pip install --user --no-deps -e anemoi-core/models
-pip install --user --no-deps -e anemoi-core/graphs
+pip install --no-deps -e anemoi-core/training
+pip install --no-deps -e anemoi-core/models
+pip install --no-deps -e anemoi-core/graphs
 
 # Clone and install utils if not already cloned
 if [ ! -d anemoi-utils ]; then
@@ -30,7 +30,7 @@ if [ ! -d anemoi-utils ]; then
     cd anemoi-utils
     cd ..
 fi
-pip install --user --no-deps -e anemoi-utils
+pip install --no-deps -e anemoi-utils
 
 # Clone and install datasets if not already cloned
 if [ ! -d anemoi-datasets ]; then
@@ -40,4 +40,4 @@ if [ ! -d anemoi-datasets ]; then
     git remote set-url origin git@github.com:metno/anemoi-datasets.git
     cd ..
 fi
-pip install --user --no-deps -e anemoi-datasets
+pip install --no-deps -e anemoi-datasets

--- a/lumi/env_setup_infer.sh
+++ b/lumi/env_setup_infer.sh
@@ -15,4 +15,4 @@ if [ ! -d bris-inference ]; then
     git remote set-url origin git@github.com:metno/bris-inference.git
     cd ..
 fi
-pip install --user --no-deps -e bris-inference
+pip install --no-deps -e bris-inference


### PR DESCRIPTION
Only change: removed `--user` from all `env_setup` scripts. Seems to do the trick. 

I can now install using the scripts, and if I want later `cd` into e.g. `bris-inference` and switch branch or edit the code and it takes affect when running (via singularity container). 

@havardhhaugen let me know if it still doesnt work for you!